### PR TITLE
Downgrade protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ keyboard==0.13.5
 pillow>=9.2.0
 requests==2.27.1
 scapy==2.4.5
-protobuf>=3.19.5
+protobuf==3.20.3


### PR DESCRIPTION
`protobuf>=3.19.5` => `protobuf==3.20.3`

## What happened?
**TypeError: Descriptors cannot not be created directly.** on [this line](https://github.com/ZaharX97/OWReveal/blob/master/csgo_demoparser/NETMSG_pb2.py#L33) when using protobuf 4
## Why
Major updates described there: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
## Solution
I guess it's temporary solution without rewriting demoparser. Latest protobuf 3 and all

## Full Error
```
Traceback (most recent call last):
  File "D:\Experiments\progs\2022\OWReveal\main.py", line 4, in <module>
    import myglobals as g
  File "D:\Experiments\progs\2022\OWReveal\myglobals.py", line 2, in <module>
    import functions as f
  File "D:\Experiments\progs\2022\OWReveal\functions.py", line 28, in <module>
    import csgo_demoparser.DemoParser as dp
  File "D:\Experiments\progs\2022\OWReveal\csgo_demoparser\DemoParser.py", line 4, in <module>
    import csgo_demoparser.NETMSG_pb2 as pbuf
  File "D:\Experiments\progs\2022\OWReveal\csgo_demoparser\NETMSG_pb2.py", line 33, in <module>
    _descriptor.EnumValueDescriptor(
  File "D:\Experiments\progs\2022\OWReveal\venv\lib\site-packages\google\protobuf\descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```
